### PR TITLE
Get UTC date in jsdateToDate

### DIFF
--- a/oholgetplayerstats.js
+++ b/oholgetplayerstats.js
@@ -564,9 +564,9 @@ function getDateStringFromUnixTime(unixTimeStamp) {
 }
 
 function jsDateToDate(jsDate, date) {
-	date[0] = jsDate.getFullYear();
-	date[1] = jsDate.getMonth()+1;
-	date[2] = jsDate.getDate();
+	date[0] = jsDate.getUTCFullYear();
+	date[1] = jsDate.getUTCMonth()+1;
+	date[2] = jsDate.getUTCDate();
 }
 
 function increaseDate(date) {

--- a/oholplayersearch.js
+++ b/oholplayersearch.js
@@ -440,9 +440,9 @@ function getDateStringFromUnixTime(unixTimeStamp) {
 }
 
 function jsDateToDate(jsDate, date) {
-	date[0] = jsDate.getFullYear();
-	date[1] = jsDate.getMonth()+1;
-	date[2] = jsDate.getDate();
+	date[0] = jsDate.getUTCFullYear();
+	date[1] = jsDate.getUTCMonth()+1;
+	date[2] = jsDate.getUTCDate();
 }
 
 function increaseDate(date) {


### PR DESCRIPTION
Get the UTC date before incrementing. This fixes a bug that caused the date to not increase across years, and also got stuck on the 10 of October. 